### PR TITLE
Update role: ansible-nvim

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: ubuntu
-    image: geerlingguy/docker-ubuntu2204-ansible
+    image: geerlingguy/docker-ubuntu2404-ansible
     pre_build_image: true
   - name: arch
     image: jahrik/docker-archlinux-ansible

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -4,10 +4,10 @@
   ansible.builtin.package:
     name:
       - curl
-      - dirmngr
       - fd-find
       - fontconfig
       - git
+      - python3-pynvim
       - python3-setuptools
       - python3-virtualenv
       - ripgrep
@@ -16,56 +16,11 @@
     update_cache: true
     cache_valid_time: 3600
 
-- name: Install python3-neovim if Ubuntu 18
-  become: true
-  ansible.builtin.package:
-    name: python3-neovim
-  when:
-    - "ansible_distribution_major_version | int >= 18"
-    - "ansible_distribution_major_version | int < 20"
-
-- name: Install python3-pynvim
-  become: true
-  ansible.builtin.package:
-    name: python3-pynvim
-  when: "ansible_distribution_major_version | int >= 20"
-
-- name: Add neovim-ppa
-  become: true
-  ansible.builtin.apt_repository:
-    repo: 'ppa:neovim-ppa/unstable'
-    update_cache: true
-
-- name: Install the gpg key for nodejs LTS
-  become: true
-  ansible.builtin.apt_key:
-    url: "https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key"
-    state: present
-
-- name: Install the nodejs 20 LTS repos
-  become: true
-  ansible.builtin.apt_repository:
-    repo: "deb https://deb.nodesource.com/node_20.x nodistro main"
-    state: present
-    update_cache: true
-
-- name: Install nodejs
+- name: Install nodejs, npm, and neovim
   become: true
   ansible.builtin.apt:
-    name: nodejs
+    name:
+      - nodejs
+      - npm
+      - neovim
     state: present
-
-- name: Gather package facts
-  become: true
-  ansible.builtin.package_facts:
-    manager: auto
-
-# Ubuntu 20.04 comes with an old version of neovim
-- name: Uninstall old versions of neovim if < 0.6
-  become: true
-  ansible.builtin.apt:
-    name: neovim
-    state: absent
-  when:
-    - "'neovim' in ansible_facts.packages"
-    - "ansible_facts.packages.neovim[0].version is version('0.6.0', '<')"


### PR DESCRIPTION
## Summary
- Bump molecule platform from Ubuntu 22.04 to Ubuntu 24.04
- Drop neovim PPA and nodesource repo (both require `gpg-agent` which isn't available in CI containers)
- Install neovim, nodejs, npm from Ubuntu 24.04 universe repos instead
- Remove Ubuntu 18/20-specific `python3-neovim`/`pynvim` version branching (not needed on 24.04)

## Test plan
- [x] `yamllint .` passes
- [x] `ansible-lint` passes
- [x] `molecule test` passes (both ubuntu and arch, converge + idempotence + verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)