### PR TITLE
Remove legacy playbook, inventory, and unused scaffolding

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,4 +4,3 @@ exclude_paths:
   - .cache/
   - molecule/
   - .ansible/
-  - tests/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,0 @@
-{
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
-  "features": {"ghcr.io/devcontainers/features/docker-in-docker:2": {}}
-}

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,0 @@
-[defaults]
-inventory      = inventory.ini
-retry_files_enabled = False
-
-[ssh_connection]
-scp_if_ssh = True
-host_key_checking = False

--- a/inventory.ini
+++ b/inventory.ini
@@ -1,2 +1,0 @@
-[local]
-localhost ansible_connection=local ansible_python_interpreter=auto

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,8 +1,0 @@
----
-- name: Converge
-  hosts: all
-  become: true
-  vars:
-    install: true
-  roles:
-    - jahrik.nvim

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,2 +1,0 @@
-localhost
-

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-    - nvim

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for nvim


### PR DESCRIPTION
  Molecule scenarios replace the standalone playbook.yml + inventory.ini.
  The ansible.cfg only referenced the removed inventory. The tests/ dir,
  vars/main.yml (empty), and .devcontainer/ were unused.