### PR TITLE
Add Nerd Fonts installation for Steam Deck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this role will be documented in this file.
 
 ### Added
 
+- Steam Deck: Install DejaVuSansMono Nerd Font to `~/.local/share/fonts` (matches Arch/Debian font install pattern)
+- Steam Deck molecule: Assert Nerd Font file exists in verify playbook
+
 - iron.nvim: Interactive REPL manager (send code to ipython/python, cell-based workflow with `# %%` markers)
 - csvview.nvim: Tabular CSV/TSV viewing with sticky headers and auto-delimiter detection
 - overseer.nvim: Task runner for dbt, pytest, and shell commands with output capture

--- a/molecule/steamdeck/verify.yml
+++ b/molecule/steamdeck/verify.yml
@@ -52,3 +52,13 @@
       ansible.builtin.assert:
         that: lsp_lua.stat.exists
         fail_msg: "~/.config/nvim/lua/plugins/lsp.lua not found"
+
+    - name: Stat Nerd Font file
+      ansible.builtin.stat:
+        path: ~/.local/share/fonts/DejaVuSansMNerdFontMono-Regular.ttf
+      register: nerd_font
+
+    - name: Assert Nerd Font is installed
+      ansible.builtin.assert:
+        that: nerd_font.stat.exists
+        fail_msg: "~/.local/share/fonts/DejaVuSansMNerdFontMono-Regular.ttf not found"

--- a/tasks/steamdeck.yml
+++ b/tasks/steamdeck.yml
@@ -103,3 +103,19 @@
       - "*/fd"
     creates: ~/.local/bin/fd
   when: not fd_stat.stat.exists
+
+- name: Create ~/.local/share/fonts directory
+  become: false
+  ansible.builtin.file:
+    path: ~/.local/share/fonts
+    state: directory
+    recurse: true
+
+- name: Download Nerd Fonts (dejavu-sans-mono-nerdfonts)
+  become: false
+  ansible.builtin.unarchive:
+    src: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.3.0/DejaVuSansMono.zip
+    dest: ~/.local/share/fonts
+    remote_src: true
+    creates: ~/.local/share/fonts/DejaVuSansMNerdFontMono-Regular.ttf
+  notify: Fc-cache


### PR DESCRIPTION
## Summary

- Install DejaVuSansMono Nerd Font to `~/.local/share/fonts` on Steam Deck, matching the existing font install pattern used by the Arch and Debian tasks
- Add Nerd Font assertion to the steamdeck molecule verify playbook

## Test plan

- [x] `mtest test -s steamdeck` passes idempotency check (`changed=0` on second converge run)
- [x] Nerd Font assertion passes in verify
- [ ] Confirm icons render correctly in terminal after running the role on a real Steam Deck