### PR TITLE
Remove font tasks, depend on jahrik.nerd_fonts

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -88,8 +88,7 @@ jobs:
         run: pip3 install ansible
 
       - name: Install requirements
-        working-directory: jahrik.nvim
-        run: ansible-galaxy install -r molecule/localhost/requirements.yml
+        run: ansible-galaxy install -r jahrik.nvim/molecule/localhost/requirements.yml -p ${{ github.workspace }}
 
       - name: Run converge
         working-directory: jahrik.nvim

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -89,19 +89,19 @@ jobs:
       - name: Install dependencies
         run: pip3 install ansible
 
-      - name: Install Galaxy requirements
-        run: ansible-galaxy role install -r jahrik.nvim/requirements.yml
+      - name: Install requirements
+        run: ansible-galaxy install -r jahrik.nvim/molecule/localhost/requirements.yml -p ${{ github.workspace }}
 
       - name: Run converge
         working-directory: jahrik.nvim
         env:
-          ANSIBLE_ROLES_PATH: ~/.ansible/roles
+          ANSIBLE_ROLES_PATH: ${{ github.workspace }}
         run: ansible-playbook molecule/localhost/converge.yml -i "localhost," -c local
 
       - name: Run verify
         working-directory: jahrik.nvim
         env:
-          ANSIBLE_ROLES_PATH: ~/.ansible/roles
+          ANSIBLE_ROLES_PATH: ${{ github.workspace }}
         run: ansible-playbook molecule/localhost/verify.yml -i "localhost," -c local
 
   release:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -21,6 +21,8 @@ jobs:
           python-version: '3.x'
       - name: Install test dependencies
         run: pip3 install yamllint ansible-lint
+      - name: Install Galaxy requirements
+        run: ansible-galaxy role install -r requirements.yml
       - name: Lint code
         run: yamllint .
       - name: Ansible lint
@@ -87,19 +89,19 @@ jobs:
       - name: Install dependencies
         run: pip3 install ansible
 
-      - name: Install requirements
-        run: ansible-galaxy install -r jahrik.nvim/molecule/localhost/requirements.yml -p ${{ github.workspace }}
+      - name: Install Galaxy requirements
+        run: ansible-galaxy role install -r jahrik.nvim/requirements.yml
 
       - name: Run converge
         working-directory: jahrik.nvim
         env:
-          ANSIBLE_ROLES_PATH: ${{ github.workspace }}
+          ANSIBLE_ROLES_PATH: ~/.ansible/roles
         run: ansible-playbook molecule/localhost/converge.yml -i "localhost," -c local
 
       - name: Run verify
         working-directory: jahrik.nvim
         env:
-          ANSIBLE_ROLES_PATH: ${{ github.workspace }}
+          ANSIBLE_ROLES_PATH: ~/.ansible/roles
         run: ansible-playbook molecule/localhost/verify.yml -i "localhost," -c local
 
   release:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Install collections
         run: ansible-galaxy collection install community.general
 
+      - name: Install roles
+        run: ansible-galaxy role install jahrik.nerd_fonts
+
       - name: Run converge
         working-directory: jahrik.nvim
         env:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -87,11 +87,9 @@ jobs:
       - name: Install dependencies
         run: pip3 install ansible
 
-      - name: Install collections
-        run: ansible-galaxy collection install community.general
-
-      - name: Install roles
-        run: ansible-galaxy role install jahrik.nerd_fonts
+      - name: Install requirements
+        working-directory: jahrik.nvim
+        run: ansible-galaxy install -r molecule/localhost/requirements.yml
 
       - name: Run converge
         working-directory: jahrik.nvim

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,4 +29,5 @@ galaxy_info:
     - lazy
     - lsp
     - python
-dependencies: []
+dependencies:
+  - role: jahrik.nerd_fonts

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,3 +1,5 @@
 ---
 collections:
   - name: community.general
+roles:
+  - name: jahrik.nerd_fonts

--- a/molecule/localhost/requirements.yml
+++ b/molecule/localhost/requirements.yml
@@ -1,3 +1,5 @@
 ---
 collections:
   - name: community.general
+roles:
+  - name: jahrik.nerd_fonts

--- a/molecule/steamdeck/requirements.yml
+++ b/molecule/steamdeck/requirements.yml
@@ -1,3 +1,5 @@
 ---
 collections:
   - name: community.general
+roles:
+  - name: jahrik.nerd_fonts

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+roles:
+  - name: jahrik.nerd_fonts

--- a/tasks/archlinux.yml
+++ b/tasks/archlinux.yml
@@ -11,4 +11,3 @@
       - tree-sitter-cli
       - unzip
     state: present
-

--- a/tasks/archlinux.yml
+++ b/tasks/archlinux.yml
@@ -12,18 +12,3 @@
       - unzip
     state: present
 
-- name: Create ~/.local/share/fonts directory
-  become: false
-  ansible.builtin.file:
-    path: ~/.local/share/fonts
-    state: directory
-    recurse: true
-
-- name: Download Nerd Fonts (dejavu-sans-mono-nerdfonts)
-  become: false
-  ansible.builtin.unarchive:
-    src: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.3.0/DejaVuSansMono.zip
-    dest: ~/.local/share/fonts
-    remote_src: true
-    creates: '~/.local/share/fonts/DejaVuSansMNerdFontMono-Regular.ttf'
-  notify: Fc-cache

--- a/tasks/darwin.yml
+++ b/tasks/darwin.yml
@@ -15,9 +15,3 @@
   community.general.homebrew:
     name: neovim
     state: present
-
-- name: Install Nerd Font (macOS)
-  become: false
-  community.general.homebrew_cask:
-    name: font-dejavu-sans-mono-nerd-font
-    state: present

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -76,18 +76,3 @@
   args:
     creates: /usr/local/bin/tree-sitter
 
-- name: Create ~/.local/share/fonts directory
-  become: false
-  ansible.builtin.file:
-    path: ~/.local/share/fonts
-    state: directory
-    recurse: true
-
-- name: Download Nerd Fonts (dejavu-sans-mono-nerdfonts)
-  become: false
-  ansible.builtin.unarchive:
-    src: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.3.0/DejaVuSansMono.zip
-    dest: ~/.local/share/fonts
-    remote_src: true
-    creates: '~/.local/share/fonts/DejaVuSansMNerdFontMono-Regular.ttf'
-  notify: Fc-cache

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -75,4 +75,3 @@
   ansible.builtin.shell: gunzip -c /tmp/tree-sitter.gz > /usr/local/bin/tree-sitter && chmod 755 /usr/local/bin/tree-sitter
   args:
     creates: /usr/local/bin/tree-sitter
-

--- a/tasks/steamdeck.yml
+++ b/tasks/steamdeck.yml
@@ -103,4 +103,3 @@
       - "*/fd"
     creates: ~/.local/bin/fd
   when: not fd_stat.stat.exists
-

--- a/tasks/steamdeck.yml
+++ b/tasks/steamdeck.yml
@@ -104,18 +104,3 @@
     creates: ~/.local/bin/fd
   when: not fd_stat.stat.exists
 
-- name: Create ~/.local/share/fonts directory
-  become: false
-  ansible.builtin.file:
-    path: ~/.local/share/fonts
-    state: directory
-    recurse: true
-
-- name: Download Nerd Fonts (dejavu-sans-mono-nerdfonts)
-  become: false
-  ansible.builtin.unarchive:
-    src: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.3.0/DejaVuSansMono.zip
-    dest: ~/.local/share/fonts
-    remote_src: true
-    creates: ~/.local/share/fonts/DejaVuSansMNerdFontMono-Regular.ttf
-  notify: Fc-cache


### PR DESCRIPTION
## Summary

- Removes duplicated Nerd Font download tasks from `archlinux.yml`, `debian.yml`, `steamdeck.yml`, and `darwin.yml`
- Adds `jahrik.nerd_fonts` as a role dependency in `meta/main.yml` — fonts are now installed by the shared role before nvim runs

## Test plan

- [x] `uv run yamllint .`
- [x] `uv run ansible-lint`
- [x] `uv run molecule test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)