### PR TITLE
fix: use ansible_distribution for SteamOS detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,9 @@ Installs [Neovim](https://neovim.io/) and deploys a full Lua-based configuration
 `tasks/main.yml` -> `install.yml` or `uninstall.yml` based on `install | bool`
 
 **install.yml:**
-1. Stat `/etc/steamos-release` -> set `is_steamdeck` fact
-2. Include OS-specific tasks: `steamdeck.yml`, `archlinux.yml`, `debian.yml`, or `darwin.yml`
-3. Create `~/.local/share/fonts`, download DejaVu Nerd Fonts, notify `Fc-cache` handler
-4. Recursive copy of `files/` to `~/.config/nvim/` (new plugins deploy without task edits)
+1. Include OS-specific tasks: `steamdeck.yml` on SteamOS, or `archlinux.yml`, `debian.yml`, or `darwin.yml` based on OS family.
+2. Create `~/.local/share/fonts`, download DejaVu Nerd Fonts, notify `Fc-cache` handler.
+3. Recursive copy of `files/` to `~/.config/nvim/` (new plugins deploy without task edits).
 
 **archlinux.yml:** pacman installs fd, fontconfig, ripgrep, unzip, tree-sitter
 

--- a/molecule/steamdeck/prepare.yml
+++ b/molecule/steamdeck/prepare.yml
@@ -18,9 +18,14 @@
         state: present
         update_cache: true
 
-    - name: Create /etc/steamos-release to trigger Steam Deck detection
+    - name: Simulate SteamOS /etc/os-release
       become: true
-      ansible.builtin.file:
-        path: /etc/steamos-release
-        state: touch
+      ansible.builtin.copy:
+        content: |
+          ID=steamos
+          ID_LIKE=arch
+          NAME="SteamOS"
+          PRETTY_NAME="SteamOS"
+          VERSION_ID="3.6"
+        dest: /etc/os-release
         mode: "0644"

--- a/molecule/steamdeck/prepare.yml
+++ b/molecule/steamdeck/prepare.yml
@@ -18,6 +18,12 @@
         state: present
         update_cache: true
 
+    - name: Remove /etc/arch-release to allow SteamOS detection
+      become: true
+      ansible.builtin.file:
+        path: /etc/arch-release
+        state: absent
+
     - name: Simulate SteamOS /etc/os-release
       become: true
       ansible.builtin.copy:
@@ -29,3 +35,4 @@
           VERSION_ID="3.6"
         dest: /etc/os-release
         mode: "0644"
+

--- a/molecule/steamdeck/prepare.yml
+++ b/molecule/steamdeck/prepare.yml
@@ -35,4 +35,3 @@
           VERSION_ID="3.6"
         dest: /etc/os-release
         mode: "0644"
-

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,12 +1,7 @@
 ---
-- name: Check for Steam Deck
-  ansible.builtin.stat:
-    path: /etc/steamos-release
-  register: steamos_release
-
 - name: Set is_steamdeck fact
   ansible.builtin.set_fact:
-    is_steamdeck: "{{ steamos_release.stat.exists }}"
+    is_steamdeck: "{{ ansible_distribution == 'SteamOS' }}"
 
 - name: Include OS specific tasks
   ansible.builtin.include_tasks: "{{ 'steamdeck' if is_steamdeck else ansible_facts['os_family'] | lower }}.yml"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,10 +1,12 @@
 ---
-- name: Set is_steamdeck fact
-  ansible.builtin.set_fact:
-    is_steamdeck: "{{ ansible_distribution == 'SteamOS' }}"
+- name: Include OS specific tasks (SteamOS)
+  ansible.builtin.include_tasks: steamdeck.yml
+  when: ansible_distribution == 'SteamOS'
 
-- name: Include OS specific tasks
-  ansible.builtin.include_tasks: "{{ 'steamdeck' if is_steamdeck else ansible_facts['os_family'] | lower }}.yml"
+- name: Include OS specific tasks (other OS)
+  ansible.builtin.include_tasks: "{{ ansible_facts['os_family'] | lower }}.yml"
+  when: ansible_distribution != 'SteamOS'
+
 
 - name: Deploy nvim configuration
   become: false

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -1,12 +1,7 @@
 ---
-- name: Check for Steam Deck
-  ansible.builtin.stat:
-    path: /etc/steamos-release
-  register: steamos_release
-
 - name: Set is_steamdeck fact
   ansible.builtin.set_fact:
-    is_steamdeck: "{{ steamos_release.stat.exists }}"
+    is_steamdeck: "{{ ansible_distribution == 'SteamOS' }}"
 
 - name: Uninstall neovim (macOS)
   become: false

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -1,8 +1,4 @@
 ---
-- name: Set is_steamdeck fact
-  ansible.builtin.set_fact:
-    is_steamdeck: "{{ ansible_distribution == 'SteamOS' }}"
-
 - name: Uninstall neovim (macOS)
   become: false
   community.general.homebrew:
@@ -19,14 +15,16 @@
     - ~/.local/bin/nvim
     - ~/.local/lib/nvim
     - ~/.local/share/nvim
-  when: is_steamdeck
+  when: ansible_distribution == 'SteamOS'
 
 - name: Uninstall neovim
   become: true
   ansible.builtin.package:
     name: neovim
     state: absent
-  when: ansible_facts['os_family'] != 'Darwin' and not is_steamdeck
+  when:
+    - ansible_facts['os_family'] != 'Darwin'
+    - ansible_distribution != 'SteamOS'
 
 - name: Destroy ~/.config/nvim directory
   become: false


### PR DESCRIPTION
## Summary
- Switch SteamOS detection from stat /etc/steamos-release to ansible_distribution == 'SteamOS'
- Remove is_steamdeck fact and deprecation overrides — inline condition is cleaner
- Remove /etc/arch-release in prepare.yml to allow correct distribution detection
- Update AGENTS.md to reflect removal of is_steamdeck

## Test plan
- [ ] Lint job passes
- [ ] Molecule default job passes (Ubuntu 24.04 + Arch)
- [ ] Molecule steamdeck job passes (SteamOS detection)
- [ ] Release job skips on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)