### PR TITLE
Add/update prepare.yml: Arch upgrade and steamdeck ordering fix

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,11 @@
+---
+- name: Prepare
+  hosts: all
+  tasks:
+    - name: Upgrade all packages to current
+      become: true
+      community.general.pacman:
+        upgrade: true
+        update_cache: true
+      changed_when: false
+      when: ansible_os_family == 'Archlinux'

--- a/molecule/steamdeck/prepare.yml
+++ b/molecule/steamdeck/prepare.yml
@@ -2,6 +2,13 @@
 - name: Prepare
   hosts: all
   tasks:
+    - name: Upgrade all packages to current
+      become: true
+      community.general.pacman:
+        upgrade: true
+        update_cache: true
+      changed_when: false
+
     - name: Install prerequisites (curl, unzip)
       become: true
       community.general.pacman:
@@ -9,7 +16,6 @@
           - curl
           - unzip
         state: present
-        update_cache: true
 
     - name: Remove /etc/arch-release to allow SteamOS detection
       become: true


### PR DESCRIPTION
## Summary
- Add `molecule/default/prepare.yml` to run `pacman -Syu` before converge
- Steamdeck prepare.yml: move `pacman -Syu` to run before SteamOS detection simulation

## Test plan
- [x] `yamllint .` — clean
- [x] `ansible-lint` — clean
- [x] `molecule test` — passed locally
- [x] CI green