### PR TITLE
fix: use ansible_distribution_release == 'holo' for SteamOS detection

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,3 +4,4 @@ exclude_paths:
   - .cache/
   - molecule/
   - .ansible/
+  - tests/

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,5 @@
 ---
-profile: basic
+profile: production
 exclude_paths:
   - .cache/
   - molecule/

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -19,14 +19,16 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.x'
+      - name: Install uv
+        run: pip3 install uv
       - name: Install test dependencies
-        run: pip3 install yamllint ansible-lint
+        run: uv sync
       - name: Install Galaxy requirements
-        run: ansible-galaxy role install -r requirements.yml
+        run: uv run ansible-galaxy role install -r requirements.yml
       - name: Lint code
-        run: yamllint .
+        run: uv run yamllint .
       - name: Ansible lint
-        run: ansible-lint
+        run: uv run ansible-lint
 
   molecule:
     name: Molecule

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -106,7 +106,7 @@ jobs:
 
   release:
     name: Release
-    needs: [molecule, macos]
+    needs: [molecule, steamdeck, macos]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check out the codebase
         uses: actions/checkout@v5
       - name: Set up Python 3
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: '3.12'
       - name: Install test dependencies
@@ -35,7 +35,7 @@ jobs:
       - name: Check out the codebase
         uses: actions/checkout@v5
       - name: Set up Python 3
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: '3.12'
       - name: Install test dependencies
@@ -53,7 +53,7 @@ jobs:
       - name: Check out the codebase
         uses: actions/checkout@v5
       - name: Set up Python 3
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: '3.12'
       - name: Install test dependencies
@@ -73,7 +73,7 @@ jobs:
         with:
           path: jahrik.nvim
       - name: Set up Python 3
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: '3.12'
       - name: Install test dependencies

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -79,9 +79,12 @@ jobs:
       - name: Install test dependencies
         working-directory: jahrik.nvim
         run: uv sync
-      - name: Install Galaxy requirements
+      - name: Install Galaxy role requirements
         working-directory: jahrik.nvim
-        run: uv run ansible-galaxy install -r molecule/localhost/requirements.yml -p ${{ github.workspace }}
+        run: uv run ansible-galaxy role install -r molecule/localhost/requirements.yml -p ${{ github.workspace }}
+      - name: Install Galaxy collection requirements
+        working-directory: jahrik.nvim
+        run: uv run ansible-galaxy collection install -r molecule/localhost/requirements.yml
       - name: Run converge
         working-directory: jahrik.nvim
         env:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: '3.12'
       - name: Install uv
         run: pip3 install uv
       - name: Install test dependencies
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Molecule
         uses: gofrolist/molecule-action@v2
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Molecule (steamdeck scenario)
         uses: gofrolist/molecule-action@v2
@@ -86,7 +86,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: pip3 install ansible

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,9 +2,9 @@
 name: CICD
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -16,11 +16,9 @@ jobs:
       - name: Check out the codebase
         uses: actions/checkout@v5
       - name: Set up Python 3
-        uses: actions/setup-python@v6
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.12'
-      - name: Install uv
-        run: pip3 install uv
       - name: Install test dependencies
         run: uv sync
       - name: Install Galaxy requirements
@@ -36,40 +34,32 @@ jobs:
     steps:
       - name: Check out the codebase
         uses: actions/checkout@v5
-
       - name: Set up Python 3
-        uses: actions/setup-python@v6
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.12'
-
-      - name: Molecule
-        uses: gofrolist/molecule-action@v2
-        with:
-          molecule_command: test
-          molecule_args: -d docker
-          molecule_working_dir: .
+      - name: Install test dependencies
+        run: uv sync
+      - name: Run Molecule
+        run: uv run molecule test
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
 
   steamdeck:
-    name: Steam Deck
+    name: Molecule (steamdeck)
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase
         uses: actions/checkout@v5
-
       - name: Set up Python 3
-        uses: actions/setup-python@v6
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.12'
-
-      - name: Molecule (steamdeck scenario)
-        uses: gofrolist/molecule-action@v2
-        with:
-          molecule_command: test
-          molecule_args: -d docker -s steamdeck
-          molecule_working_dir: .
+      - name: Install test dependencies
+        run: uv sync
+      - name: Run Molecule
+        run: uv run molecule test -s steamdeck
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
@@ -82,33 +72,30 @@ jobs:
         uses: actions/checkout@v5
         with:
           path: jahrik.nvim
-
       - name: Set up Python 3
-        uses: actions/setup-python@v6
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.12'
-
-      - name: Install dependencies
-        run: pip3 install ansible
-
-      - name: Install requirements
-        run: ansible-galaxy install -r jahrik.nvim/molecule/localhost/requirements.yml -p ${{ github.workspace }}
-
+      - name: Install test dependencies
+        working-directory: jahrik.nvim
+        run: uv sync
+      - name: Install Galaxy requirements
+        working-directory: jahrik.nvim
+        run: uv run ansible-galaxy install -r molecule/localhost/requirements.yml -p ${{ github.workspace }}
       - name: Run converge
         working-directory: jahrik.nvim
         env:
           ANSIBLE_ROLES_PATH: ${{ github.workspace }}
-        run: ansible-playbook molecule/localhost/converge.yml -i "localhost," -c local
-
+        run: uv run ansible-playbook molecule/localhost/converge.yml -i "localhost," -c local
       - name: Run verify
         working-directory: jahrik.nvim
         env:
           ANSIBLE_ROLES_PATH: ${{ github.workspace }}
-        run: ansible-playbook molecule/localhost/verify.yml -i "localhost," -c local
+        run: uv run ansible-playbook molecule/localhost/verify.yml -i "localhost," -c local
 
   release:
     name: Release
-    needs: [molecule, steamdeck, macos]
+    needs: [lint, molecule, steamdeck, macos]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:

--- a/.yamllint
+++ b/.yamllint
@@ -1,5 +1,8 @@
 ---
 extends: default
+
+ignore: |
+  .venv/
 rules:
   braces:
     max-spaces-inside: 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,8 @@ Each plugin is a self-contained spec returned from its file. lazy.nvim auto-impo
 ## Testing
 
 ```bash
+uv sync
+source .venv/bin/activate
 yamllint .
 ansible-lint
 molecule test

--- a/README.md
+++ b/README.md
@@ -234,6 +234,10 @@ To uninstall:
 ## Testing
 
 ```bash
+uv sync
+source .venv/bin/activate
+yamllint .
+ansible-lint
 molecule test
 ```
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   description: Install Neovim with a full Lua config managed by lazy.nvim
   issue_tracker_url: https://github.com/jahrik/ansible-nvim/issues
   license: GPLv2
-  min_ansible_version: "2.15"
+  min_ansible_version: '2.16'
   platforms:
     - name: ArchLinux
       versions:

--- a/molecule/steamdeck/prepare.yml
+++ b/molecule/steamdeck/prepare.yml
@@ -32,5 +32,6 @@
           NAME="SteamOS"
           PRETTY_NAME="SteamOS"
           VERSION_ID="3.6"
+          VERSION_CODENAME=holo
         dest: /etc/os-release
         mode: "0644"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,11 @@
 [project]
 name = "ansible-nvim"
 version = "0.1.0"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
 dependencies = [
-    "docker>=7.1.0",
-    "molecule>=26.4.0",
-    "molecule-plugins[docker]>=25.8.12",
-]
-
-[dependency-groups]
-dev = [
-    "molecule",
-    "molecule-plugins[docker]",
-    "ansible-core",
-    "docker",
-    "ansible-lint",
+    "ansible-core>=2.16,<2.18",
+    "ansible-lint>=24.0.0",
+    "molecule>=24.0.0",
+    "molecule-plugins[docker]>=23.0.0",
+    "yamllint>=1.38.0",
 ]

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,11 +1,11 @@
 ---
 - name: Include OS specific tasks (SteamOS)
   ansible.builtin.include_tasks: steamdeck.yml
-  when: ansible_distribution == 'SteamOS'
+  when: ansible_distribution_release == 'holo'
 
 - name: Include OS specific tasks (other OS)
   ansible.builtin.include_tasks: "{{ ansible_facts['os_family'] | lower }}.yml"
-  when: ansible_distribution != 'SteamOS'
+  when: ansible_distribution_release != 'holo'
 
 
 - name: Deploy nvim configuration

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Install
   ansible.builtin.include_tasks: install.yml
-  when: install
+  when: install | default(true) | bool
 
 - name: Uninstall
   ansible.builtin.include_tasks: uninstall.yml
-  when: not install
+  when: not (install | default(true) | bool)

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -15,7 +15,7 @@
     - ~/.local/bin/nvim
     - ~/.local/lib/nvim
     - ~/.local/share/nvim
-  when: ansible_distribution == 'SteamOS'
+  when: ansible_distribution_release == 'holo'
 
 - name: Uninstall neovim
   become: true
@@ -24,7 +24,7 @@
     state: absent
   when:
     - ansible_facts['os_family'] != 'Darwin'
-    - ansible_distribution != 'SteamOS'
+    - ansible_distribution_release != 'holo'
 
 - name: Destroy ~/.config/nvim directory
   become: false


### PR DESCRIPTION
## Summary

Replace \`ansible_distribution == 'SteamOS'\` with \`ansible_distribution_release == 'holo'\` throughout.

## Root cause

Ansible reads \`/etc/arch-release\` on SteamOS before \`/etc/os-release\`, so \`ansible_distribution\` reports \`Archlinux\` instead of \`SteamOS\` on the real device. Every SteamOS guard was silently broken — tasks that should be skipped (like \`pacman\` with \`become: true\`) were running and hitting sudo errors.

\`ansible_distribution_release\` reads \`VERSION_CODENAME\` from \`/etc/os-release\`, which is \`holo\` on all SteamOS versions. This is the reliable identifier.

The molecule steamdeck \`prepare.yml\` is also updated to include \`VERSION_CODENAME=holo\` in the simulated \`/etc/os-release\` so CI continues to work.

## Test plan

- [ ] \`ansible localhost -c local -m setup -a "filter=ansible_distribution_release"\` returns \`holo\`
- [ ] \`molecule test -s steamdeck\` passes
- [ ] \`molecule test -s localhost\` passes (SteamOS tasks skip correctly without sudo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)