### PR TITLE
fix: use ansible_distribution_release == 'holo' for SteamOS detection

### DIFF
--- a/molecule/steamdeck/prepare.yml
+++ b/molecule/steamdeck/prepare.yml
@@ -32,5 +32,6 @@
           NAME="SteamOS"
           PRETTY_NAME="SteamOS"
           VERSION_ID="3.6"
+          VERSION_CODENAME=holo
         dest: /etc/os-release
         mode: "0644"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,11 +1,11 @@
 ---
 - name: Include OS specific tasks (SteamOS)
   ansible.builtin.include_tasks: steamdeck.yml
-  when: ansible_distribution == 'SteamOS'
+  when: ansible_distribution_release == 'holo'
 
 - name: Include OS specific tasks (other OS)
   ansible.builtin.include_tasks: "{{ ansible_facts['os_family'] | lower }}.yml"
-  when: ansible_distribution != 'SteamOS'
+  when: ansible_distribution_release != 'holo'
 
 
 - name: Deploy nvim configuration

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -15,7 +15,7 @@
     - ~/.local/bin/nvim
     - ~/.local/lib/nvim
     - ~/.local/share/nvim
-  when: ansible_distribution == 'SteamOS'
+  when: ansible_distribution_release == 'holo'
 
 - name: Uninstall neovim
   become: true
@@ -24,7 +24,7 @@
     state: absent
   when:
     - ansible_facts['os_family'] != 'Darwin'
-    - ansible_distribution != 'SteamOS'
+    - ansible_distribution_release != 'holo'
 
 - name: Destroy ~/.config/nvim directory
   become: false


### PR DESCRIPTION
## Summary

Replace \`ansible_distribution == 'SteamOS'\` with \`ansible_distribution_release == 'holo'\` throughout.

## Root cause

Ansible reads \`/etc/arch-release\` on SteamOS before \`/etc/os-release\`, so \`ansible_distribution\` reports \`Archlinux\` instead of \`SteamOS\` on the real device. Every SteamOS guard was silently broken.

\`ansible_distribution_release\` reads \`VERSION_CODENAME\` from \`/etc/os-release\`, which is \`holo\` on all SteamOS versions. Molecule steamdeck \`prepare.yml\` updated to include \`VERSION_CODENAME=holo\` so CI continues to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)