### PR TITLE
Update role: ansible-nvim — bump CI action pins

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Set up Python 3
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: '3.12'
       - name: Install test dependencies
@@ -33,9 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Set up Python 3
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: '3.12'
       - name: Install test dependencies
@@ -51,9 +51,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Set up Python 3
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: '3.12'
       - name: Install test dependencies
@@ -69,11 +69,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out the codebase
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           path: jahrik.nvim
       - name: Set up Python 3
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           python-version: '3.12'
       - name: Install test dependencies
@@ -103,7 +103,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: galaxy
         uses: robertdebock/galaxy-action@1.2.1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        exclude: .*/test/.*
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+        args: ["--maxkb=500"]
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-json
+      - id: check-case-conflict
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        types_or: [markdown, json]
+
+  - repo: local
+    hooks:
+      - id: yamllint
+        name: yamllint
+        entry: uv run yamllint
+        language: system
+        types: [yaml]
+
+      - id: ansible-lint
+        name: ansible-lint
+        entry: uv run ansible-lint
+        language: system
+        pass_filenames: false
+        always_run: true


### PR DESCRIPTION
Brings the repo in line with the current `update-ansible-role` standard:

- **CI action pins**: `actions/checkout` v5 → v7, `astral-sh/setup-uv` v8.1.0 → v8.2.0
- **pre-commit**: add `.pre-commit-config.yaml` (gitleaks, detect-secrets, pre-commit-hooks, prettier on markdown/json, local `uv run` yamllint + ansible-lint)

## Test plan
- [ ] Lint ✅
- [ ] Molecule ✅
- [ ] Release ⏭ (after merge to main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)