### PR TITLE
Update role: ansible-nvim — bump Ubuntu 26.04 + ansible-core 2.21

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: ubuntu
-    image: geerlingguy/docker-ubuntu2404-ansible
+    image: geerlingguy/docker-ubuntu2604-ansible
     pre_build_image: true
   - name: arch
     image: jahrik/docker-archlinux-ansible

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "ansible-nvim"
 version = "0.1.0"
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.12,<3.14"
 dependencies = [
-    "ansible-core>=2.16,<2.18",
+    "ansible-core>=2.16,<2.22",
     "ansible-lint>=24.0.0",
     "molecule>=24.0.0",
     "molecule-plugins[docker]>=23.0.0",


### PR DESCRIPTION
## Changes
- **Molecule base image** → `geerlingguy/docker-ubuntu2604-ansible` (Ubuntu 26.04 LTS)
- **`ansible-core`** `<2.18` → `<2.22`; `uv lock --upgrade` resolves to **2.21.1**
- **`requires-python`** `>=3.11` → `>=3.12` (ansible-core 2.20+ needs Python ≥3.12; CI is 3.12-only)

## Test plan
- [x] `uv run yamllint .` + `uv run ansible-lint` — clean, production profile
- [x] `molecule test -s default` — converge ✅, idempotence (changed=0) ✅, verify ✅
- [ ] CI: lint, molecule, release

🤖 Generated with [Claude Code](https://claude.com/claude-code)