### PR TITLE
Fix copilot.lua install timeout on partial clone checkout

### DIFF
--- a/files/lua/core/lazy.lua
+++ b/files/lua/core/lazy.lua
@@ -26,6 +26,9 @@ require("lazy").setup({
 			lazy = "💤 ",
 		},
 	},
+	git = {
+		timeout = 600,
+	},
 	install = {
 		missing = true,
 		colorscheme = { "catppuccin" },

--- a/files/lua/plugins/copilot.lua
+++ b/files/lua/plugins/copilot.lua
@@ -1,7 +1,6 @@
 return {
 	"zbirenbaum/copilot.lua",
 	branch = "master",
-	version = "*",
 	cmd = "Copilot",
 	event = "InsertEnter",
 


### PR DESCRIPTION
### Summary

- Remove `version = "*"` from copilot.lua plugin spec to avoid conflict with `branch = "master"`
- Increase lazy.nvim git timeout from default 120s to 600s to accommodate slow blob fetches during partial clone checkouts

### Test plan

- [x] `rm -rf ~/.local/share/nvim/lazy/copilot.lua` and open nvim
- [x] Verify copilot.lua installs successfully without timeout
- [x] Verify `:Copilot status` works after install
- [x] Verify other plugins still install normally